### PR TITLE
Add: テキストメール送信時のメールヘッダーにMIME-VersionおよびContext-Typeを追加.

### DIFF
--- a/deploy/src/perihelion/php/model/mail.model.php
+++ b/deploy/src/perihelion/php/model/mail.model.php
@@ -40,9 +40,10 @@ class Mail extends ORM {
 
 		$mailHeader = "From: $mailSender\n";
 		$mailHeader .= "Reply-To: $mailSender\n";
+		$mailHeader .= "MIME-Version: 1.0\n";
+		$mailHeader .= "Content-Type: text/plain; charset=UTF-8\n";
 			
 		if ($mailType == 'html') {
-			$mailHeader .= "MIME-Version: 1.0\n";
 			$mailHeader .= "Content-Type: text/html; charset=UTF-8\n";
 		}
 


### PR DESCRIPTION
-- ・MIME-Version: 1.0の指定がHTMLメールのみだったため、テキストメールでも指定する様に変更.
-- ・テキストメール時は、Content-Type: text/plain; charset=UTF-8を指定する様に変更. (変更前は両方とも未指定)
-- 　(HTMLメールは既に、Content-Type: text/html; charset=UTF-8が指定されているので問題なし)