### PR TITLE
Add: PHPからのメール送信時にメールヘッダーのfrom指定を追加.

### DIFF
--- a/deploy/src/perihelion/php/model/mail.model.php
+++ b/deploy/src/perihelion/php/model/mail.model.php
@@ -51,7 +51,7 @@ class Mail extends ORM {
 		
 		
 		
-		if (mail($mailRecipient,$mailSubject,$mailMessage,$mailHeader)) {
+		if (mail($mailRecipient,$mailSubject,$mailMessage,$mailHeader, '-f ' . $mailSender)) {
 			
 			// SAVE MAIL TO DB
 			$mail = new Mail();


### PR DESCRIPTION
-- ・Docker環境には本指定が必須で、検証サーバー上でも本指定ありでの動作確認済み.